### PR TITLE
Docs: migrate Coveralls badge to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
     <a href="https://github.com/contributte/nextras-orm-events/actions"><img src="https://badgen.net/github/checks/contributte/nextras-orm-events"></a>
-    <a href="https://coveralls.io/r/contributte/nextras-orm-events"><img src="https://badgen.net/coveralls/c/github/contributte/nextras-orm-events"></a>
+    <a href="https://codecov.io/gh/contributte/nextras-orm-events"><img src="https://badgen.net/codecov/c/github/contributte/nextras-orm-events"></a>
     <a href="https://packagist.org/packages/contributte/nextras-orm-events"><img src="https://badgen.net/packagist/dm/contributte/nextras-orm-events"></a>
     <a href="https://packagist.org/packages/contributte/nextras-orm-events"><img src="https://badgen.net/packagist/v/contributte/nextras-orm-events"></a>
 </p>


### PR DESCRIPTION
Closes contributte/contributte#72.

## What changed
- replaced the README coverage badge link from Coveralls to Codecov
- confirmed the repository already uses the shared Codecov-ready coverage workflow, so no workflow changes were needed
- confirmed there is no obsolete `tests/.coveralls.yml` file to remove

## Why
- finishes the remaining Coveralls-to-Codecov migration for this repository so coverage links stay consistent with the current reporting setup