### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this repository with the org-wide coverage migration tracked in contributte/contributte#73

## Motivation
- `phpdbg` is being removed from coverage targets across Contributte so coverage runs use plain `php`

## Changes
- update both CI and local coverage commands in `Makefile`

## Testing
- [x] `make coverage` starts the updated `php` command
- [ ] Coverage completes locally (`php` in this environment has no Xdebug/PCOV, and PHPDBG is intentionally no longer used)
- [ ] CI passes