### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed

- Added `secrets: inherit` to `.github/workflows/coverage.yml` so the reusable coverage workflow receives repository secrets from the caller.

## Why

- The coverage workflow rollout for contributte/contributte#74 requires reusable workflow callers to explicitly inherit secrets so coverage-related tokens remain available in CI.